### PR TITLE
fix(embeddings): update dimensions from 768 to 3072 for gemini-embedding-001

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -50,7 +50,7 @@ class Settings(BaseSettings):
 
     # Embedding Configuration
     EMBEDDING_MODEL: str = "models/gemini-embedding-001"
-    EMBEDDING_DIMENSIONS: int = 768
+    EMBEDDING_DIMENSIONS: int = 3072
 
     # Chunking Configuration
     CHUNK_SIZE_MIN: int = 400

--- a/migrations/007_update_embedding_dimensions.sql
+++ b/migrations/007_update_embedding_dimensions.sql
@@ -1,0 +1,161 @@
+-- Migration 007: Update embedding dimensions from 768 to 3072
+-- Required for gemini-embedding-001 which outputs 3072 dimensions
+
+-- Update the column type
+ALTER TABLE chunks ALTER COLUMN embedding TYPE vector(3072);
+
+-- Drop and recreate vector search functions with updated dimensions
+
+CREATE OR REPLACE FUNCTION search_chunks(
+    query_embedding vector(3072),
+    match_count int DEFAULT 10,
+    similarity_threshold float DEFAULT 0.7
+)
+RETURNS TABLE (
+    id uuid,
+    document_id uuid,
+    content text,
+    contextual_content text,
+    similarity float,
+    metadata jsonb
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        c.id,
+        c.document_id,
+        c.content,
+        c.contextual_content,
+        1 - (c.embedding <=> query_embedding) as similarity,
+        (c.metadata || jsonb_build_object(
+            'document_name', d.filename,
+            'chunk_index', c.chunk_index
+        )) as metadata
+    FROM chunks c
+    JOIN documents d ON c.document_id = d.id
+    WHERE 1 - (c.embedding <=> query_embedding) >= similarity_threshold
+    ORDER BY c.embedding <=> query_embedding
+    LIMIT match_count;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION search_chunks_by_document(
+    query_embedding vector(3072),
+    target_document_id uuid,
+    match_count int DEFAULT 10,
+    similarity_threshold float DEFAULT 0.7
+)
+RETURNS TABLE (
+    id uuid,
+    document_id uuid,
+    content text,
+    contextual_content text,
+    similarity float,
+    metadata jsonb
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        c.id,
+        c.document_id,
+        c.content,
+        c.contextual_content,
+        1 - (c.embedding <=> query_embedding) as similarity,
+        (c.metadata || jsonb_build_object(
+            'document_name', d.filename,
+            'chunk_index', c.chunk_index
+        )) as metadata
+    FROM chunks c
+    JOIN documents d ON c.document_id = d.id
+    WHERE c.document_id = target_document_id
+        AND 1 - (c.embedding <=> query_embedding) >= similarity_threshold
+    ORDER BY c.embedding <=> query_embedding
+    LIMIT match_count;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION search_chunks_by_session(
+    query_embedding vector(3072),
+    user_session_id varchar(255),
+    match_count int DEFAULT 10,
+    similarity_threshold float DEFAULT 0.5
+)
+RETURNS TABLE (
+    id uuid,
+    document_id uuid,
+    content text,
+    contextual_content text,
+    similarity float,
+    metadata jsonb
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        c.id,
+        c.document_id,
+        c.content,
+        c.contextual_content,
+        1 - (c.embedding <=> query_embedding) as similarity,
+        (c.metadata || jsonb_build_object(
+            'document_name', d.filename,
+            'chunk_index', c.chunk_index
+        )) as metadata
+    FROM chunks c
+    JOIN documents d ON c.document_id = d.id
+    WHERE (d.session_id = user_session_id OR d.session_id = 'global')
+        AND 1 - (c.embedding <=> query_embedding) >= similarity_threshold
+    ORDER BY c.embedding <=> query_embedding
+    LIMIT match_count;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION search_chunks_by_document_and_session(
+    query_embedding vector(3072),
+    target_document_id uuid,
+    user_session_id varchar(255),
+    match_count int DEFAULT 10,
+    similarity_threshold float DEFAULT 0.5
+)
+RETURNS TABLE (
+    id uuid,
+    document_id uuid,
+    content text,
+    contextual_content text,
+    similarity float,
+    metadata jsonb
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        c.id,
+        c.document_id,
+        c.content,
+        c.contextual_content,
+        1 - (c.embedding <=> query_embedding) as similarity,
+        (c.metadata || jsonb_build_object(
+            'document_name', d.filename,
+            'chunk_index', c.chunk_index
+        )) as metadata
+    FROM chunks c
+    JOIN documents d ON c.document_id = d.id
+    WHERE c.document_id = target_document_id
+        AND (d.session_id = user_session_id OR d.session_id = 'global')
+        AND 1 - (c.embedding <=> query_embedding) >= similarity_threshold
+    ORDER BY c.embedding <=> query_embedding
+    LIMIT match_count;
+END;
+$$;
+
+DO $$
+BEGIN
+  RAISE NOTICE 'Migration 007_update_embedding_dimensions.sql completed successfully!';
+  RAISE NOTICE 'Updated embedding column and all vector search functions from 768 to 3072 dimensions';
+END $$;

--- a/tests/unit/test_embeddings.py
+++ b/tests/unit/test_embeddings.py
@@ -38,14 +38,14 @@ def test_init_failure(mock_genai):
 def test_generate_embedding_success(embedding_service, mock_genai):
     """Test successful embedding generation."""
     # Mock the embed_content response
-    mock_embedding = [0.1] * 768
+    mock_embedding = [0.1] * 3072
     mock_genai.embed_content.return_value = {"embedding": mock_embedding}
 
     text = "This is a test document."
     result = embedding_service.generate_embedding(text)
 
     assert result == mock_embedding
-    assert len(result) == 768
+    assert len(result) == 3072
     mock_genai.embed_content.assert_called_once_with(
         model="models/gemini-embedding-001",
         content=text,
@@ -68,7 +68,7 @@ def test_generate_embedding_wrong_dimensions(embedding_service, mock_genai):
     mock_embedding = [0.1] * 512  # Wrong size
     mock_genai.embed_content.return_value = {"embedding": mock_embedding}
 
-    with pytest.raises(DocumentProcessingError, match="Expected 768 dimensions"):
+    with pytest.raises(DocumentProcessingError, match="Expected 3072 dimensions"):
         embedding_service.generate_embedding("test")
 
 
@@ -83,14 +83,14 @@ def test_generate_embedding_api_error(embedding_service, mock_genai):
 def test_generate_embeddings_batch_success(embedding_service, mock_genai):
     """Test successful batch embedding generation."""
     # Mock the embed_content response
-    mock_embedding = [0.1] * 768
+    mock_embedding = [0.1] * 3072
     mock_genai.embed_content.return_value = {"embedding": mock_embedding}
 
     texts = ["Text 1", "Text 2", "Text 3"]
     results = embedding_service.generate_embeddings_batch(texts)
 
     assert len(results) == 3
-    assert all(len(emb) == 768 for emb in results)
+    assert all(len(emb) == 3072 for emb in results)
     assert mock_genai.embed_content.call_count == 3
 
 
@@ -102,7 +102,7 @@ def test_generate_embeddings_batch_empty_list(embedding_service):
 
 def test_generate_embeddings_batch_with_empty_texts(embedding_service, mock_genai):
     """Test batch generation with some empty texts."""
-    mock_embedding = [0.1] * 768
+    mock_embedding = [0.1] * 3072
     mock_genai.embed_content.return_value = {"embedding": mock_embedding}
 
     texts = ["Text 1", "", "Text 3", "   "]
@@ -110,8 +110,8 @@ def test_generate_embeddings_batch_with_empty_texts(embedding_service, mock_gena
 
     assert len(results) == 4
     # Empty texts should have zero vectors
-    assert results[1] == [0.0] * 768
-    assert results[3] == [0.0] * 768
+    assert results[1] == [0.0] * 3072
+    assert results[3] == [0.0] * 3072
     # Non-empty texts should have real embeddings
     assert results[0] == mock_embedding
     assert results[2] == mock_embedding
@@ -121,7 +121,7 @@ def test_generate_embeddings_batch_with_empty_texts(embedding_service, mock_gena
 
 def test_generate_embeddings_batch_large(embedding_service, mock_genai):
     """Test batch generation with large number of texts."""
-    mock_embedding = [0.1] * 768
+    mock_embedding = [0.1] * 3072
     mock_genai.embed_content.return_value = {"embedding": mock_embedding}
 
     # Create 250 texts (more than default batch size of 100)
@@ -129,14 +129,14 @@ def test_generate_embeddings_batch_large(embedding_service, mock_genai):
     results = embedding_service.generate_embeddings_batch(texts, batch_size=100)
 
     assert len(results) == 250
-    assert all(len(emb) == 768 for emb in results)
+    assert all(len(emb) == 3072 for emb in results)
     # Should have called API 250 times (once per text)
     assert mock_genai.embed_content.call_count == 250
 
 
 def test_generate_embeddings_batch_custom_batch_size(embedding_service, mock_genai):
     """Test batch generation with custom batch size."""
-    mock_embedding = [0.1] * 768
+    mock_embedding = [0.1] * 3072
     mock_genai.embed_content.return_value = {"embedding": mock_embedding}
 
     texts = [f"Text {i}" for i in range(10)]
@@ -148,14 +148,14 @@ def test_generate_embeddings_batch_custom_batch_size(embedding_service, mock_gen
 
 def test_generate_query_embedding_success(embedding_service, mock_genai):
     """Test successful query embedding generation."""
-    mock_embedding = [0.2] * 768
+    mock_embedding = [0.2] * 3072
     mock_genai.embed_content.return_value = {"embedding": mock_embedding}
 
     query = "What is the capital of France?"
     result = embedding_service.generate_query_embedding(query)
 
     assert result == mock_embedding
-    assert len(result) == 768
+    assert len(result) == 3072
     mock_genai.embed_content.assert_called_once_with(
         model="models/gemini-embedding-001",
         content=query,
@@ -177,7 +177,7 @@ def test_generate_query_embedding_wrong_dimensions(embedding_service, mock_genai
     mock_embedding = [0.1] * 512  # Wrong size
     mock_genai.embed_content.return_value = {"embedding": mock_embedding}
 
-    with pytest.raises(DocumentProcessingError, match="Expected 768 dimensions"):
+    with pytest.raises(DocumentProcessingError, match="Expected 3072 dimensions"):
         embedding_service.generate_query_embedding("test query")
 
 
@@ -193,8 +193,8 @@ def test_generate_query_embedding_api_error(embedding_service, mock_genai):
 
 def test_embedding_dimensions_consistency(embedding_service, mock_genai):
     """Test that all embeddings have consistent dimensions."""
-    mock_embedding_1 = [0.1] * 768
-    mock_embedding_2 = [0.2] * 768
+    mock_embedding_1 = [0.1] * 3072
+    mock_embedding_2 = [0.2] * 3072
 
     # Different embeddings for different texts
     mock_genai.embed_content.side_effect = [
@@ -205,7 +205,7 @@ def test_embedding_dimensions_consistency(embedding_service, mock_genai):
     text_emb = embedding_service.generate_embedding("document text")
     query_emb = embedding_service.generate_query_embedding("query text")
 
-    assert len(text_emb) == len(query_emb) == 768
+    assert len(text_emb) == len(query_emb) == 3072
 
 
 def test_batch_processing_maintains_order(embedding_service, mock_genai):
@@ -213,7 +213,7 @@ def test_batch_processing_maintains_order(embedding_service, mock_genai):
 
     # Create unique embeddings for each text
     def create_mock_embedding(index):
-        return {"embedding": [float(index)] * 768}
+        return {"embedding": [float(index)] * 3072}
 
     texts = [f"Text {i}" for i in range(5)]
 


### PR DESCRIPTION
## Summary
- Add migration 007 to alter `chunks.embedding` column from `vector(768)` to `vector(3072)`
- Recreate all vector search functions with updated dimensions
- Update `EMBEDDING_DIMENSIONS` in config from 768 to 3072

## Why
`gemini-embedding-001` outputs 3072 dimensions vs 768 for the deprecated `text-embedding-004`. Without this migration, embedding generation and vector search will fail.

## Test plan
- [ ] Run migration 007 on the database
- [ ] Re-upload sample documents to regenerate embeddings
- [ ] Verify vector search returns results

🤖 Generated with [Claude Code](https://claude.com/claude-code)