### PR TITLE
chore: update LLM model to claude-sonnet-4-5 and fix migration 007

### DIFF
--- a/Claude.md
+++ b/Claude.md
@@ -688,6 +688,21 @@ This project follows trunk-based development:
 5. **Link PRs to issues** with "Fixes #N"
 6. **Use descriptive commit messages** (not "fix bug")
 
+### Before Committing Config/Constant Changes
+
+When changing any hardcoded value (model names, dimensions, thresholds, URLs), **always grep the test suite for the old value** before committing:
+
+```bash
+grep -rn "old-value" tests/
+```
+
+Tests in `tests/unit/` frequently hardcode config values in mock assertions. Changing a constant in `config.py` without updating the tests will cause CI to fail. This has happened with:
+
+- `EMBEDDING_MODEL` — tests assert the exact model string in mock call args
+- `EMBEDDING_DIMENSIONS` — tests use hardcoded dimension sizes in mock responses
+
+**Rule:** change the config → grep tests → update any hardcoded references → commit together.
+
 ### When Things Break
 
 1. Check backend logs first

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -75,7 +75,7 @@ class Settings(BaseSettings):
 
     # LLM Configuration (via Openrouter)
     OPENROUTER_BASE_URL: str = "https://openrouter.ai/api/v1"
-    LLM_MODEL: str = "anthropic/claude-3.5-sonnet"  # Openrouter format
+    LLM_MODEL: str = "anthropic/claude-sonnet-4-5"  # Openrouter format
     LLM_TEMPERATURE: float = 0.3
     LLM_MAX_TOKENS: int = 2048
 

--- a/migrations/007_update_embedding_dimensions.sql
+++ b/migrations/007_update_embedding_dimensions.sql
@@ -1,8 +1,14 @@
 -- Migration 007: Update embedding dimensions from 768 to 3072
 -- Required for gemini-embedding-001 which outputs 3072 dimensions
 
+-- Drop vector index before altering column type (required by pgvector)
+DROP INDEX IF EXISTS idx_chunks_embedding;
+
 -- Update the column type
 ALTER TABLE chunks ALTER COLUMN embedding TYPE vector(3072);
+
+-- Recreate the vector index for the new dimensions
+CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON chunks USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);
 
 -- Drop and recreate vector search functions with updated dimensions
 


### PR DESCRIPTION
## Summary
- Update `LLM_MODEL` default from `anthropic/claude-3.5-sonnet` to `anthropic/claude-sonnet-4-5`
- Add `DROP INDEX IF EXISTS idx_chunks_embedding` before `ALTER TABLE` in migration 007 so it runs cleanly on fresh deploys
- Recreate IVFFlat index after column type change

## Notes
- `.env.production` is not in the repo — no changes needed there

🤖 Generated with [Claude Code](https://claude.com/claude-code)